### PR TITLE
Deploy production builds to the prod-pages branch.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,8 +21,8 @@ jobs:
           command: bundle exec jekyll build --config _config_prod.yml
       - add_ssh_keys:
           fingerprints:
-            # Replace this with the fingerprint for gh-prod.
-            - "9e:47:8e:0e:f1:51:5a:70:9f:6c:09:fd:e1:a2:ba:da"
+            # Replace this with the fingerprint for gh-stg.
+            - "10:e9:26:42:e2:cc:1b:de:b5:db:47:95:f0:37:68:7b"
       - run:
           name: Deploy to Github
           command: bash scripts/deploy/circleci/deploy_prod.sh

--- a/scripts/deploy/circleci/deploy_prod.sh
+++ b/scripts/deploy/circleci/deploy_prod.sh
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
+# This script deploys the built site to the prod-pages branch of the same repo.
 git config --global user.email $GH_EMAIL
 git config --global user.name $GH_NAME
 
 # CircleCI will identify the SSH key with a "Host" of gh-stg. In order to tell
 # Git to use this key, we need to hack the SSH key:
-sed -i -e 's/Host gh-prod/Host gh-prod\n  HostName github.com/g' ~/.ssh/config
-# Now we can use "gh-prod" below to identify the SSH key to use.
-git clone git@gh-prod:$GH_ORG_PROD/$GH_ORG_PROD.github.io.git out
+sed -i -e 's/Host gh-stg/Host gh-stg\n  HostName github.com/g' ~/.ssh/config
+# Now we can use "gh-stg" below to identify the SSH key to use.
+git clone git@gh-stg:$GH_ORG_STG/$CIRCLE_PROJECT_REPONAME.git out
 
 cd out
-git checkout master || git checkout --orphan master
+git checkout prod-pages || git checkout --orphan prod-pages
 git rm -rfq .
 cd ..
 
@@ -20,6 +21,6 @@ mkdir -p out/.circleci && cp -a .circleci/. out/.circleci/.
 cd out
 
 git add -A
-git commit -m "Automated deployment to GitHub Pages: ${CIRCLE_SHA1}" --allow-empty
+git commit -m "Automated deployment to prod-pages: ${CIRCLE_SHA1}" --allow-empty
 
-git push origin master
+git push origin prod-pages

--- a/scripts/deploy/circleci/deploy_staging.sh
+++ b/scripts/deploy/circleci/deploy_staging.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# This script deploys the built site to the gh-pages branch of the same repo.
 git config --global user.email $GH_EMAIL
 git config --global user.name $GH_NAME
 
@@ -6,7 +7,7 @@ git config --global user.name $GH_NAME
 # Git to use this key, we need to hack the SSH key:
 sed -i -e 's/Host gh-stg/Host gh-stg\n  HostName github.com/g' ~/.ssh/config
 # Now we can use "gh-stg" below to identify the SSH key to use.
-git clone git@gh-stg:$GH_ORG_STG/sdg-indicators-usa.git out
+git clone git@gh-stg:$GH_ORG_STG/$CIRCLE_PROJECT_REPONAME.git out
 
 cd out
 git checkout gh-pages || git checkout --orphan gh-pages


### PR DESCRIPTION
This production deployment approach listens for changes to the master branch, builds the site and pushes to the prod-pages branch in the same repository.