### PR TITLE
Fix the '%name' appearing on the instructions line.

### DIFF
--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -2,7 +2,8 @@
 {% include header.html %}
 {% include us_heading.html text=t.usa.heading_us %}
 <div id="main-content" class="container goal-tiles" role="main">
-    <p>{{ t.frontpage.instructions | replace_first: '%before_link', '<span style="display:none" id="jump-to-search"><a href="javascript:void(0)">' | replace_first: '%after_link', '</a></span>' | replace_first: '%country_name', site.country.name }}</p>
+    {% assign country_name = site.country.name | t %}
+    <p>{{ t.frontpage.instructions | replace_first: '%before_link', '<span style="display:none" id="jump-to-search"><a href="javascript:void(0)">' | replace_first: '%after_link', '</a></span>' | replace_first: '%name', country_name }}</p>
     {%- assign goals = site.goals | where: 'language', current_language -%}
     {% for goal in goals %}
         {%- assign goal_number = goal.sdg_goal -%}


### PR DESCRIPTION
@philipashlock I missed one bit - there is a '%name' appearing in the instructions line on the homepage. This should fix that.

I'm going ahead and running `site.country.name` through the "t" filter, even though it's technically not needed yet. If we ever have need to translate "US" into other languages, having it run through the t filter will make that easier.