### PR TITLE
Add back the GA number

### DIFF
--- a/_config_prod.yml
+++ b/_config_prod.yml
@@ -26,7 +26,7 @@ jekyll_get_json:
     json: 'https://gsa.github.io/sdg-translations/translations-0.4.0.json'
 
 analytics:
-  ga_prod: ''
+  ga_prod: 'UA-42145528-4'
 
 ###################################################################################################
 email_contacts:


### PR DESCRIPTION
@philipashlock The GA number unfortunately was lost in [this commit](https://github.com/GSA/sdg-indicators-usa/commit/5d1f311fa1522e6cf9fe622acd4acfe3e1c2200f#diff-0b42f6a3317776244ee3f87a6f93f8e1). This adds it back so that production analytics will be tracked again.