### PR TITLE
Federalist support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
             - vendor/bundle
       - run:
           name: Build the Jekyll site
-          command: bundle exec jekyll build
+          command: bundle exec jekyll build --config _config_dev.yml
       - run:
           name: Run the HTML tests
           command: bash scripts/test/html_proofer_staging.sh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
+[![CircleCI](https://circleci.com/gh/GSA/sdg-indicators-usa.svg?style=svg)](https://circleci.com/gh/GSA/sdg-indicators-usa)
+
 # Sustainable Development Goal indicators
 
 This is a development website for collecting and disseminating US data for the Sustainable Development Goal global indicators.
 
 For any guidance on how to use the website or develop it further for your own country, please refer to the [wiki](https://github.com/ONSdigital/sdg-indicators/wiki).
- 

--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -8,25 +8,26 @@
 # Site settings
 title: U.S. Indicators For The Sustainable Development Goals
 description: Data Platform Prototype
-baseurl: "" # the subpath of your site, e.g. /blog
+baseurl: "/sdg-indicators-usa" # the subpath of your site, e.g. /blog
 url: ""
 data_dir: data
-environment: production
-remotedatabaseurl: "https://gsa.github.io/sdg-data-usa/prod"
+data_dir_for_edits: data-wide
+environment: staging
+remotedatabaseurl: "https://gsa.github.io/sdg-data-usa/staging"
 # permalink: /news/:year/:month/:day/:title.html
 
 jekyll_get_json:
   - data: meta
-    json: 'https://gsa.github.io/sdg-data-usa/prod/meta/all.json'
+    json: 'https://gsa.github.io/sdg-data-usa/staging/meta/all.json'
   - data: headlines
-    json: 'https://gsa.github.io/sdg-data-usa/prod/headline/all.json'
+    json: 'https://gsa.github.io/sdg-data-usa/staging/headline/all.json'
   - data: schema
-    json: 'https://gsa.github.io/sdg-data-usa/prod/meta/schema.json'
+    json: 'https://gsa.github.io/sdg-data-usa/staging/meta/schema.json'
   - data: translations
     json: 'https://gsa.github.io/sdg-translations/translations-0.4.0.json'
 
 analytics:
-  ga_prod: 'UA-42145528-4'
+  ga_prod: ''
 
 ###################################################################################################
 email_contacts:
@@ -44,13 +45,7 @@ org_name: GSA
 markdown: kramdown
 
 # Travis Support
-exclude:
-  - vendor
-  - scripts
-  - remotedata
-  - Gemfile
-  - Gemfile.lock
-  - README.md
+exclude: [vendor, scripts, remotedata]
 
 # International Support
 # Eg name: Australia and adjective: Australian


### PR DESCRIPTION
Hey folks,

The Data.gov team wants to move our static websites to [Federalist](https://federalist.18f.gov/). This should simplify your workflow at all and will give you the benefit of branch previews. For example, you can see the [preview of this branch](https://federalist-proxy.app.cloud.gov/preview/gsa/sdg-indicators-usa/federalist/) before merging it.

There wasn't any real changes I had to make since you're already using `site.baseurl` to prefix URLs. Once the site is live on federalist, we should be able to remove custom GitHub Pages builds that are happening.

Please post here with any questions or comments.