### PR TITLE
Make main/master the default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,17 @@ See [CONTRIBUTING](CONTRIBUTING.md) for additional information.
 
 This site is automatically published based on the branch.
 
-Branch    | Environment | URL
-------    | ----------- | ---
-`develop` | staging     | [sdg-staging.data.gov](https://sdg-staging.data.gov/)
-`master`  | production  | [sdg.data.gov](https://sdg.data.gov/)
+Branch    | Environment | URL | Description
+------    | ----------- | --- | -----------
+`develop` | staging     | [sdg-staging.data.gov](https://sdg-staging.data.gov/) | Ad-hoc development and reviewing significant changes with partners.
+`main`  | production  | [sdg.data.gov](https://sdg.data.gov/) | Production instance  of sdg.data.gov.
+
+Federalist automatically builds previews for all branches. Changes to `main` are
+automatically published to [sdg.data.gov](https://sdg.data.gov/).
+Feature branches should be branched from `main`.
+
+`develop` is used ad-hoc in order to preview significant changes with partners
+and is not part of the development workflow.
 
 
 ## Public domain


### PR DESCRIPTION
https://github.com/GSA/datagov-deploy/issues/2001

This proposes we simplify our workflow to make `main` the default branch.
`master` will be renamed to `main`. Feature branches will be branched from
`main` and then merged directly to `main` without going to staging/`develop`
first.

The staging site is used ad-hoc for significant changes but is otherwise unused.