### PR TITLE
Metadata config tweaks

### DIFF
--- a/_data/site_config.yml
+++ b/_data/site_config.yml
@@ -113,8 +113,9 @@ indicator_metadata_form:
   language: ''
   scopes:
     - national
-    - global
-  exclude_fields: []
+  exclude_fields:
+    - national_data_updated_date
+    - national_metadata_updated_date
   translated: false
 indicator_tabs:
   tab_1: ''

--- a/_data/site_config.yml
+++ b/_data/site_config.yml
@@ -100,15 +100,15 @@ ignored_disaggregations: []
 indicator_config_form:
   enabled: true
   dropdowns: []
-  repository_link: /tree/develop/indicator-config
+  repository_link: /tree/main/indicator-config
   translation_link: ''
 indicator_data_form:
   enabled: true
-  repository_link: /tree/develop/data
+  repository_link: /tree/main/data
 indicator_metadata_form:
   enabled: true
   dropdowns: []
-  repository_link: /tree/develop/meta
+  repository_link: /tree/main/meta
   translation_link: ''
   language: ''
   scopes:


### PR DESCRIPTION
This PR keeps "global" and other automated fields out of the metadata forms that data providers will use to maintain metadata. It also fixes the "go to repository" buttons in the config forms, since the data repo uses the "main" branch instead of develop.